### PR TITLE
Allow the end user to customize the required claims

### DIFF
--- a/spec/JwtDecoder.spec.php
+++ b/spec/JwtDecoder.spec.php
@@ -12,11 +12,11 @@ describe('JwtDecoder', function () {
     beforeEach(function () {
         $this->jwt = "eyJraWQiOiI4WG9DOUxBOE9uSE1FTG1hcmxHc1BhWWI4WTVDdVYwZ1RMMzJzVkVaRjdnPSIsImFsZyI6IlJTMjU2In0.eyJzdWIiOiI5NmY4YzQ0Mi04MTlkLTQ3NzQtODNlNC04NDAxZDU2ZjYwZWMiLCJhdWQiOiI2dDk4MTNzMGR2bzZwbGo1bmFxdjY5NnE5OSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJldmVudF9pZCI6ImQzY2M1MDZiLWIzZTctNDk2My04NDYyLTYyZWI5YzFlM2Q3ZiIsInRva2VuX3VzZSI6ImlkIiwiYXV0aF90aW1lIjoxNTc5NjM5NDIzLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAudXMtZWFzdC0yLmFtYXpvbmF3cy5jb21cL3VzLWVhc3QtMl9kUkNueVZHVUciLCJjdXN0b206dXNlcl9pZCI6IjEyMyIsImNvZ25pdG86dXNlcm5hbWUiOiI5NmY4YzQ0Mi04MTlkLTQ3NzQtODNlNC04NDAxZDU2ZjYwZWMiLCJleHAiOjE1Nzk2NDMwMjMsImlhdCI6MTU3OTYzOTQyMywiZW1haWwiOiJpc2htYWVsQHRlYW1nYW50dC5jb20ifQ.OYUvrp-rKy_-A9eisMahC9s1GSQrx5ElgX36gNGO6RLLYZXe2DOVJTO1UgVupjcKM3bDscpSjUweQiOBupvnkDlN4bHHAfERsRPpCwtRMWQW7MGGB6FIJ5yb3K3ObEZcD-P_ASJ7a7BIvr4tTvnzKqiDh2zXnmeo1Jhe62bxsuu_57Z1lW9ju79SdqLCqZUxw20b7kQTO173NUe0biAKMXjElYv9_zW0nc9a6Yx8LVVHUJT8KN4v0VnGJnNIIpRJHRCHTd4sJpEg3rOgHubIiuuUZhyZS1-qVG3D4OlD2d9MtTgQOrgdaorxg6JAIza3TPmRZ7CoQMndtgRqNq34Aw";
         $this->validJwk = realpath(__DIR__ . DIRECTORY_SEPARATOR . 'jwk.valid.json');
-        $verifier = Double::instance(['implements' => ClaimVerifierInterface::class]);
-        allow($verifier)->toReceive('verify')->andRun(function ($token) {
+        $this->verifier = Double::instance(['implements' => ClaimVerifierInterface::class]);
+        allow($this->verifier)->toReceive('verify')->andRun(function ($token) {
             return $token;
         });
-        $this->decoder = new JwtDecoder($verifier);
+        $this->decoder = new JwtDecoder($this->verifier);
 
         // Give it a leeway of 100 years to allow testing decoding the token without exception
         JWT::$leeway = 60 * 60 * 24 * 365 * 100;
@@ -47,6 +47,14 @@ describe('JwtDecoder', function () {
             $token = $this->decoder->decode($this->jwt, $this->validJwk);
             expect($token->getClaim('custom:user_id'))->toBe('123');
             expect($token->getClaim('token_use'))->toBe('id');
+        });
+
+        it('should throw an exception for a missing claim key', function () {
+            $decoderWithExtraRequiredKey = new JwtDecoder($this->verifier, ['custom:foo']);
+            $sut = function () use ($decoderWithExtraRequiredKey) {
+                $decoderWithExtraRequiredKey->decode($this->jwt, $this->validJwk);
+            };
+            expect($sut)->toThrow(new DomainException("claim custom:foo not found"));
         });
 
         it('should throw an exception for expired tokens', function () {

--- a/src/JwtDecoder.php
+++ b/src/JwtDecoder.php
@@ -24,13 +24,20 @@ class JwtDecoder implements DecoderInterface
     protected $verifier;
 
     /**
+     * @var array<string>
+     */
+    protected $extraRequiredClaims;
+
+    /**
      * JwtDecoder constructor.
      *
      * @param ClaimVerifierInterface $verifier
+     * @param array<string> $extraRequiredClaims
      */
-    public function __construct(ClaimVerifierInterface $verifier)
+    public function __construct(ClaimVerifierInterface $verifier, array $extraRequiredClaims = [])
     {
         $this->verifier = $verifier;
+        $this->extraRequiredClaims = $extraRequiredClaims;
     }
 
     /**
@@ -51,7 +58,7 @@ class JwtDecoder implements DecoderInterface
 
         $claims = $this->getVerifiedToken($kid, $keyPath, $token);
 
-        return $this->verifier->verify(new Token($claims));
+        return $this->verifier->verify(new Token($claims, $this->extraRequiredClaims));
     }
 
     /**

--- a/src/Models/Token.php
+++ b/src/Models/Token.php
@@ -4,6 +4,13 @@ namespace TeamGantt\Juhwit\Models;
 
 class Token
 {
+    const BASE_REQUIRED_CLAIMS = [
+        'aud',
+        'iss',
+        'token_use',
+        'email',
+    ];
+
     /**
      * @var array
      */
@@ -14,9 +21,9 @@ class Token
      *
      * @param array $claims
      */
-    public function __construct(array $claims)
+    public function __construct(array $claims, $extraRequiredClaims = [])
     {
-        $this->invariant($claims);
+        $this->invariant($claims, $extraRequiredClaims);
         $this->claims = $claims;
     }
 
@@ -46,24 +53,18 @@ class Token
 
     /**
      * Validate the claims the Token was constructed with. This is a semi opinionated
-     * list of required keys for a JWT from Cognito - including a single custom attribute.
-     * Future versions may relax this requirement
+     * list of required keys for a JWT from Cognito.
      *
      * @param array $claims
+     * @param array<string> $claims
      *
      * @throws \DomainException
      *
      * @return void
      */
-    private function invariant(array $claims)
+    private function invariant(array $claims, array $extraRequiredClaims)
     {
-        $requiredKeys = [
-            'aud',
-            'iss',
-            'token_use',
-            'email',
-            'custom:user_id',
-        ];
+        $requiredKeys = array_merge(self::BASE_REQUIRED_CLAIMS, $extraRequiredClaims);
 
         foreach ($requiredKeys as $requiredKey) {
             if (!isset($claims[$requiredKey])) {


### PR DESCRIPTION
Hey :wave: 

I was starting to integrate your library to validate our Cognito token. When I could not validate our JWT token because of a required custom field in the token content validation:

https://github.com/teamgantt/juhwit/blob/c54fa5576159af3b3377fc368f6bb6d3ec43a117/src/Models/Token.php#L60-L66

This PR follow your comment suggestion :stuck_out_tongue_winking_eye:  by changing the default behaviour: no custom field are mandatory by default. It also add an option on the decoder to allow end user to add their own custom fields to require.

I did not update the JwtProvider as I have no idea how this work :sweat_smile:  

I'm available to improve the PR if you need some change.

