### PR TITLE
feat: support multiple clients for aud claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ use TeamGantt\Juhwit\JwtDecoder;
 use TeamGantt\Juhwit\CognitoClaimVerifier;
 
 // Create a CognitoClaimVerifier with information about the AWS user pool
-$clientId = 'some client id from cognito';
+$clientIds = ['some client id from cognito'];
 $poolId = 'some pool id from cognito';
 $region = 'us-east-2';
 
-$verifier = new CognitoClaimVerifier($clientId, $poolId, $region);
+$verifier = new CognitoClaimVerifier($clientIds, $poolId, $region);
 $decoder = new JwtDecoder($verifier);
 
 // we need some public keys in the form of a jwk (accessible via cognito)

--- a/spec/CognitoClaimVerifier.spec.php
+++ b/spec/CognitoClaimVerifier.spec.php
@@ -6,17 +6,17 @@ use TeamGantt\Juhwit\CognitoClaimVerifier;
 
 describe('CognitoClaimVerifier', function () {
     beforeEach(function () {
-        $this->clientId = 'client';
+        $this->clientIds = ['client'];
         $this->poolId = 'pool';
         $this->region = 'us-east-2';
         $this->claims = [
-            'aud' => $this->clientId,
+            'aud' => $this->clientIds[0],
             'iss' => 'https://cognito-idp.us-east-2.amazonaws.com/pool',
             'token_use' => 'id',
             'email' => 'brian@internet.com',
             'custom:user_id' => 123
         ];
-        $this->verifier = new CognitoClaimVerifier($this->clientId, $this->poolId, $this->region);
+        $this->verifier = new CognitoClaimVerifier($this->clientIds, $this->poolId, $this->region);
     });
 
     describe('->verify()', function () {
@@ -40,7 +40,7 @@ describe('CognitoClaimVerifier', function () {
         });
 
         it('should throw an exception if the iss claim does not match the pool id', function () {
-            $verifier = new CognitoClaimVerifier($this->clientId, 'ham', $this->region);
+            $verifier = new CognitoClaimVerifier($this->clientIds, 'ham', $this->region);
             $token = new Token($this->claims);
 
             $sut = function () use ($verifier, $token) {
@@ -51,7 +51,7 @@ describe('CognitoClaimVerifier', function () {
         });
 
         it('should throw an exception if the iss claim does not match the region', function () {
-            $verifier = new CognitoClaimVerifier($this->clientId, $this->poolId, 'ham');
+            $verifier = new CognitoClaimVerifier($this->clientIds, $this->poolId, 'ham');
             $token = new Token($this->claims);
 
             $sut = function () use ($verifier, $token) {

--- a/src/CognitoClaimVerifier.php
+++ b/src/CognitoClaimVerifier.php
@@ -9,9 +9,9 @@ use TeamGantt\Juhwit\Exceptions\InvalidClaimsException;
 class CognitoClaimVerifier implements ClaimVerifierInterface
 {
     /**
-     * @var string
+     * @var string[]
      */
-    protected $clientId;
+    protected $clientIds;
 
     /**
      * @var string
@@ -26,13 +26,13 @@ class CognitoClaimVerifier implements ClaimVerifierInterface
     /**
      * CognitoClaimVerifier constructor.
      *
-     * @param string $clientId
+     * @param string[] $clientId
      * @param string $poolId
      * @param string $region
      */
-    public function __construct(string $clientId, string $poolId, string $region)
+    public function __construct(array $clientIds, string $poolId, string $region)
     {
-        $this->clientId = $clientId;
+        $this->clientIds = $clientIds;
         $this->poolId = $poolId;
         $this->region = $region;
     }
@@ -52,7 +52,7 @@ class CognitoClaimVerifier implements ClaimVerifierInterface
         $iss = $token->getClaim('iss');
         $tokenUse = $token->getClaim('token_use');
 
-        if ($aud !== $this->clientId) {
+        if (array_search($aud, $this->clientIds) === false) {
             throw new InvalidClaimsException('Invalid aud claim');
         }
 


### PR DESCRIPTION
If a cognito user pool has multiple clients, it becomes tricky to validate tokens from multiple clients.

This changes forces the claims verifier to accept an array of supported clients to allow for multiple clients.

This should probably be a major version bump